### PR TITLE
Release/v0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,23 @@
----
 language: python
 python:
-  - "2.7"
-
-# Use container infra
+- '2.7'
 sudo: false
-
 env:
-  - DJANGO_VERSION=1.10.6
-  - DJANGO_VERSION=1.9.12
-  - DJANGO_VERSION=1.8.17
-
+- DJANGO_VERSION=1.10.6
+- DJANGO_VERSION=1.9.12
+- DJANGO_VERSION=1.8.17
 install:
-  # Install specific Django version
-  - pip install Django==$DJANGO_VERSION
-
+- pip install Django==$DJANGO_VERSION
 script:
-  - make test
-
+- make test
 notifications:
   slack: tlt:KyqrXDeFkXKb72AsDYTwWkNp
+deploy:
+  provider: pypi
+  user: tlt_opensource
+  password:
+    secure: EpwpuJyk4HydSAPdBwCULoC0BVUA3q+pxmQQIVmrHdDYroWVUfiFXL2tj9RhQa6zp9Xrwp8naz97Hp8lhFwi+jNeq4ZLSTD1UMvvcP+H8ncFWe/nEwmJs/89GRegyV/dtEYAIM7vp0AIGldHcaFh9pzItuNLBdsuybwGzLoRgidXnNu3qKzFJKaOZV8SNjoBzm2NdMbo+NWOr/btgng3p1jGZEMgh52riROwUYx8SUGjieJuQ86FlOIET3OVZ9bY0kmvNRzMe1XqQP+eSCvE9PrmycvY4V2RtmXzqPfvgYXn+MdWz2imeoxvNt1FV4UjJZUyG3dvMsk2H23jEzwhU3e7b9wE7V8TMWEFVgE98vW6a0HHbWLNBMZEaBMMzCYTwMZ69Ojjtelt5dNmLKpmFjN2Pg/RDZsSZ7b4vav/9ktDCFaLbY3mAq7MRMU8nrE+mlzcrPeNtn/jvfKlKYTnFhZg9gTqBoJKlhlY2z+XBRP4lZgBM3hGT85aE5IXWMrPsnhIbOWjpUSH5CMZUTXOSyFWXYjG/nteygwCzn6DISrpd2qApHrlhDCiJdG/0tQ+D6EilpXuCRCSNb3hyA5tEFUZznwsn7gnraFBulDwNFhw9wdket6SYzlD+BtbAaAoLw9PhPIrg+81XwTcnrSPdN1qpXZTmMg3a+RPfkjKdZI=
+  on:
+    tags: true
+    distributions: sdist bdist_wheel
+    repo: Harvard-University-iCommons/dj-log-config-helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+---
+language: python
+python:
+  - "2.7"
+
+# Use container infra
+sudo: false
+
+env:
+  - DJANGO_VERSION=1.10.6
+  - DJANGO_VERSION=1.9.12
+  - DJANGO_VERSION=1.8.17
+
+install:
+  # Install specific Django version
+  - pip install Django==$DJANGO_VERSION
+
+script:
+  - make test
+
+notifications:
+  slack: tlt:KyqrXDeFkXKb72AsDYTwWkNp

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 init:
-	pip install django
+	pip install Django
 
 test: init
 	python test_dj_log_config_helper.py

--- a/README.rst
+++ b/README.rst
@@ -39,10 +39,13 @@ Disable Django's default logging::
     LOGGING_CONFIG = None
 
 At the end of ``settings.py`` configure a simple console logger::
-    
+
     configure_installed_apps_logger(logging.INFO)
-    
 
 Or, configure a verbose file logger::
 
     configure_installed_apps_logger(logging.INFO, verbose=True, filename='django-project.log')
+
+You can also log additional packages that are not part of INSTALLED_APPS::
+
+    configure_installed_apps_logger(logging.INFO, additional_packages=['py.warnings'])

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = ['django']
 
 setup(
     name='dj-log-config-helper',
-    version='0.1.0',
+    version='0.2.0',
     url='https://github.com/Harvard-University-iCommons/dj-log-config-helper',
     author='Jaime Bermudez',
     author_email='jaime_bermudez@harvard.edu',

--- a/test_dj_log_config_helper.py
+++ b/test_dj_log_config_helper.py
@@ -16,8 +16,19 @@ import dj_log_config_helper as log_helper
 class LogHelperTestSuite(SimpleTestCase):
     """Basic test cases."""
 
+    def test_app_modules_are_normalized(self):
+        app_modules = [
+            'django.contrib.auth',
+            'django.contrib.sessions',
+            'django.contrib.messages'
+        ]
+        apps = log_helper._normalize_apps(app_modules)
+
+        self.assertEqual(len(apps), 1)
+        self.assertIn('django', apps)
+
     def test_app_loggers_empty_when_no_apps(self):
-        loggers = log_helper.build_normalized_app_loggers(
+        loggers = log_helper.build_app_loggers(
             logging.DEBUG,
             []
         )
@@ -26,7 +37,7 @@ class LogHelperTestSuite(SimpleTestCase):
     def test_app_loggers_built_with_default_handler(self):
         level = logging.INFO
         apps = ['django.contrib.auth', 'myapp']
-        loggers = log_helper.build_normalized_app_loggers(level, apps)
+        loggers = log_helper.build_app_loggers(level, apps)
 
         self.assertTrue(loggers)
         for key, value in loggers.iteritems():
@@ -39,7 +50,7 @@ class LogHelperTestSuite(SimpleTestCase):
         level = logging.INFO
         apps = ['django']
         handlers = ['handler1', 'handler2']
-        loggers = log_helper.build_normalized_app_loggers(level, apps, handlers)
+        loggers = log_helper.build_app_loggers(level, apps, handlers)
 
         self.assertEqual(loggers['django']['handlers'], handlers)
 
@@ -47,28 +58,16 @@ class LogHelperTestSuite(SimpleTestCase):
         level = logging.INFO
         apps = ['django']
         str_handler = 'myhandler'
-        loggers = log_helper.build_normalized_app_loggers(
+        loggers = log_helper.build_app_loggers(
             level, apps, str_handler)
 
         self.assertEqual(loggers['django']['handlers'], list(str_handler))
-
-    def test_app_loggers_are_normalized(self):
-        level = logging.INFO
-        apps = [
-            'django.contrib.auth',
-            'django.contrib.sessions',
-            'django.contrib.messages'
-        ]
-        loggers = log_helper.build_normalized_app_loggers(level, apps)
-
-        self.assertEqual(len(loggers), 1)
-        self.assertIn('django', loggers.keys())
 
     def test_build_config_defaults(self):
         level = logging.WARNING
         verbose = False
         apps = ['django.contrib.auth']
-        config = log_helper._build_config(
+        config = log_helper._build_logging_config(
             level, apps, verbose)
 
         self.assertEqual(config['handlers']['default']['class'], 'logging.StreamHandler')
@@ -81,7 +80,7 @@ class LogHelperTestSuite(SimpleTestCase):
         apps = ['django.contrib.auth']
         # Must be a path that is writable
         tf = tempfile.NamedTemporaryFile()
-        config = log_helper._build_config(
+        config = log_helper._build_logging_config(
             level, apps, verbose, filename=tf.name)
 
         self.assertEqual(
@@ -90,7 +89,7 @@ class LogHelperTestSuite(SimpleTestCase):
         self.assertEqual(
             config['handlers']['default']['filename'], tf.name)
 
-    def test_build_config_app_loggers(self):
+    def test_build_log_config_app_loggers(self):
         level = logging.WARNING
         verbose = False
         apps = [
@@ -98,16 +97,16 @@ class LogHelperTestSuite(SimpleTestCase):
             'django.contrib.sessions',
             'django.contrib.messages'
         ]
-        config = log_helper._build_config(
+        config = log_helper._build_logging_config(
             level, apps, verbose)
 
         loggers = config['loggers']
-        self.assertTrue(len(loggers), 1)
-        self.assertEqual(loggers['django']['level'], level)
-        self.assertEqual(loggers['django']['handlers'], ['default'])
-        self.assertEqual(loggers['django']['propagate'], False)
+        self.assertTrue(len(loggers), 3)
+        self.assertEqual(loggers['django.contrib.auth']['level'], level)
+        self.assertEqual(loggers['django.contrib.auth']['handlers'], ['default'])
+        self.assertEqual(loggers['django.contrib.auth']['propagate'], False)
 
-    def test_build_config_verbose_mode(self):
+    def test_build_log_config_verbose_mode(self):
         level = logging.WARNING
         verbose = True
         apps = [
@@ -115,7 +114,7 @@ class LogHelperTestSuite(SimpleTestCase):
             'django.contrib.sessions',
             'django.contrib.messages'
         ]
-        config = log_helper._build_config(
+        config = log_helper._build_logging_config(
             level, apps, verbose)
 
         self.assertEqual(
@@ -127,9 +126,8 @@ class LogHelperTestSuite(SimpleTestCase):
         with self.assertRaises(ImproperlyConfigured):
             log_helper.configure_installed_apps_logger(logging.DEBUG)
 
-    @override_settings(
-        LOGGING_CONFIG=None)
-    def test_configured_django_logger(self):
+    @override_settings(LOGGING_CONFIG=None)
+    def test_configured_installed_apps_logger_defaults(self):
         """Test out the configuration of the 'django' logger when LOGGING_CONFIG is set
         to None.  The configuration is expected to be done in a project's
         settings file, so to simulate that we need to first configure the logger
@@ -152,6 +150,55 @@ class LogHelperTestSuite(SimpleTestCase):
         self.assertEqual(dj_logger.handlers[0].name, 'default')
         self.assertEqual(dj_logger.level, logging.INFO)
         self.assertEqual(dj_logger.propagate, False)
+
+    @override_settings(LOGGING_CONFIG=None)
+    def test_configured_installed_apps_logger_with_added_packages_list(self):
+        """Test out the configuration of an additional package logger. """
+
+        pkgs = ['rq.worker']
+
+        log_helper.configure_installed_apps_logger(logging.INFO,
+                                                   additional_packages=pkgs)
+
+        # Need to set up the application registry in order to access
+        # installed_apps
+        django.setup()
+
+        # A logger should have been set up for the additional app package with
+        # the default handler, and given level and propagation
+        additional_logger = logging.getLogger(pkgs[0])
+        self.assertEqual(len(additional_logger.handlers), 1)
+        self.assertIsInstance(additional_logger.handlers[0],
+                              logging.StreamHandler)
+        self.assertEqual(additional_logger.handlers[0].name, 'default')
+        self.assertEqual(additional_logger.level, logging.INFO)
+        self.assertEqual(additional_logger.propagate, False)
+
+    @override_settings(LOGGING_CONFIG=None)
+    def test_configured_installed_apps_logger_with_added_packages_string(self):
+        """Test out the configuration of an additional package logger passed in as
+        a string instead of a list.
+        """
+
+        pkg = 'rq.worker'
+
+        log_helper.configure_installed_apps_logger(logging.INFO,
+                                                   additional_packages=pkg)
+
+        # Need to set up the application registry in order to access
+        # installed_apps
+        django.setup()
+
+        # A logger should have been set up for the additional app package with
+        # the default handler, and given level and propagation
+        additional_logger = logging.getLogger(pkg)
+        self.assertEqual(len(additional_logger.handlers), 1)
+        self.assertIsInstance(additional_logger.handlers[0],
+                              logging.StreamHandler)
+        self.assertEqual(additional_logger.handlers[0].name, 'default')
+        self.assertEqual(additional_logger.level, logging.INFO)
+        self.assertEqual(additional_logger.propagate, False)
+
 
 if __name__ == '__main__':
     # Test without a settings file by calling settings.configure


### PR DESCRIPTION
This PR/Release adds an optional `additional_packages` parameter so users can define an additional set of library packages to log, outside of INSTALLED_APPS. This would allow for `py.warnings` as well as dependent libraries to be logged as needed, for example.  In addition, the logic to normalize list of installed apps within the `configure_installed_apps` method as opposed to doing so at a higher level.  A Travis CI integration has been added that uses the Makefile to test against several versions of Django, reports back to Slack, and on a successful tagged build will publish the package to PyPi.

@elliottyates 
@sapnamysore 